### PR TITLE
Adjust API client to not silently accept API problems

### DIFF
--- a/custom_components/posten/api.py
+++ b/custom_components/posten/api.py
@@ -1,63 +1,81 @@
-"""Sample API Client."""
-import logging
+"""Posten API Client."""
+from __future__ import annotations
+
 import asyncio
 import base64
 import time
 import socket
-from typing import Optional
 import aiohttp
-import async_timeout
 
 TIMEOUT = 10
 
-_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+class PostenApiError(Exception):
+    """Posten API error."""
+
 
 class IntegrationPostenApiClient:
-    def __init__(
-        self, postalcode: str, session: aiohttp.ClientSession
-    ) -> None:
-        """Sample API Client."""
+    """Posten API Client."""
+
+    def __init__(self, postalcode: str, session: aiohttp.ClientSession) -> None:
+        """Psten API Client."""
         self._session = session
         self._postalcode = postalcode
 
     async def async_get_data(self) -> dict:
-        """Get data from the API."""
-        """I think a way to get around postens stupid api keys, please do not change this posten we are just trying to get your data. Im pretty sure this data goes under offentleglova anyways so please stop changing it <3"""
-        token = (base64.b64encode(bytes(base64.b64decode("f3ccd044MTY4MjYyODE2MQ==")[0:6]) + bytes(str(int(time.time())), "utf8")).decode().replace("=", ""))
-        HEADERS = {"content-type": "application/json; charset=UTF-8", "x-requested-with": "XMLHttpRequest", "kp-api-token": token}
-        url = "https://www.posten.no/levering-av-post/_/service/no.posten.website/delivery-days?postalCode="+self._postalcode
-        return await self.api_wrapper(method="get", url=url, headers=HEADERS)
+        """Get data from the API.
+
+        I think a way to get around postens stupid api keys,
+        please do not change this posten we are just trying to get your data.
+        Im pretty sure this data goes under offentleglova anyways so please stop changing it <3
+        """
+        return await self.api_wrapper(
+            method="get",
+            url=f"https://www.posten.no/levering-av-post/_/service/no.posten.website/delivery-days?postalCode={self._postalcode}",
+            headers={
+                "content-type": "application/json; charset=UTF-8",
+                "x-requested-with": "XMLHttpRequest",
+                "kp-api-token": base64.b64encode(
+                    bytes(base64.b64decode("f3ccd044MTY4MjYyODE2MQ==")[0:6])
+                    + bytes(str(int(time.time())), "utf8")
+                )
+                .decode()
+                .replace("=", ""),
+            },
+        )
 
     async def api_wrapper(
-        self, method: str, url: str, data: dict = {}, headers: dict = {}
+        self,
+        method: str,
+        url: str,
+        headers: dict | None = None,
     ) -> dict:
         """Get information from the API."""
         try:
-            async with async_timeout.timeout(TIMEOUT):
-                if method == "get":
-                    response = await self._session.request(method, url, headers=headers)
-                    return await response.json()
-                else:
-                    await self._session.request(method, url, headers=headers, json=data)
+            response = await self._session.request(
+                method,
+                url,
+                headers=headers or {},
+                timeout=aiohttp.ClientTimeout(total=TIMEOUT),
+            )
+            return await response.json()
 
         except asyncio.TimeoutError as exception:
-            _LOGGER.error(
-                "Timeout error fetching information from %s - %s",
-                url,
-                exception,
-            )
+            raise PostenApiError(
+                f"Timeout error fetching information from {url}"
+            ) from exception
 
         except (KeyError, TypeError) as exception:
-            _LOGGER.error(
-                "Error parsing information from %s - %s",
-                url,
-                exception,
-            )
+            raise PostenApiError(
+                f"Error parsing information from {url} - {exception}"
+            ) from exception
+
         except (aiohttp.ClientError, socket.gaierror) as exception:
-            _LOGGER.error(
-                "Error fetching information from %s - %s",
-                url,
-                exception,
-            )
+            raise PostenApiError(
+                f"Error fetching information from {url} - {exception}"
+            ) from exception
+
         except Exception as exception:  # pylint: disable=broad-except
-            _LOGGER.error("Something really wrong happened! - %s", exception)
+            raise PostenApiError(
+                f"Something really wrong happened! - {exception}"
+            ) from exception


### PR DESCRIPTION
- No longer silently accept issues by returning `None` from the API client.
- Removed `post` (non-get) handler in the API client, as that was not used.
- Add an instance check in coordinator to validate the data type returned.

These changes will allow the integration to retry automatically if there are issues during setup.

Fixes #20 